### PR TITLE
Make it possible to use an env var to point to custom genePredToGtf binary

### DIFF
--- a/R/annotation.R
+++ b/R/annotation.R
@@ -1876,8 +1876,13 @@ getUcscUtr <- function(org,refdb="ucsc") {
     # Do the conversion stuff. AS there is no easy way to check if genePredToGtf
     # exists in the system, we should download it on the fly (once for the 
     # session). If no Linux machine, then problem.
-    genePredToGtf <- file.path(tempdir(),"genePredToGtf")
-    if (!file.exists(file.path(tempdir(),"genePredToGtf"))) {
+    genePredToGtfEnv <- Sys.getenv("GENEPREDTOGTF_BINARY")
+    if (genePredToGtfEnv == "") {
+        genePredToGtf <- file.path(customDir,"genePredToGtf")
+    } else {
+        genePredToGtf <- file.path(genePredToGtfEnv)
+    }
+    if (!file.exists(genePredToGtf)) {
         message("  Retrieving genePredToGtf tool")
         download.file(
         "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/genePredToGtf",

--- a/vignettes/metaseqr2-annotation.Rmd
+++ b/vignettes/metaseqr2-annotation.Rmd
@@ -211,7 +211,12 @@ if (.Platform$OS.type == "unix" && !grepl("^darwin",R.version$os)) {
     chromInfo <- chromInfo[,2,drop=FALSE]
     
     # Coversion from genePred to GTF
-    genePredToGtf <- file.path(customDir,"genePredToGtf")
+    genePredToGtfEnv <- Sys.getenv("GENEPREDTOGTF_BINARY")
+    if (genePredToGtfEnv == "") {
+        genePredToGtf <- file.path(customDir,"genePredToGtf")
+    } else {
+        genePredToGtf <- file.path(genePredToGtfEnv)
+    }
     if (!file.exists(genePredToGtf)) {
         download.file(
         "http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/genePredToGtf",


### PR DESCRIPTION
This way the builder (e.g. https://bioconductor.org/checkResults/3.18/bioc-LATEST/kunpeng2-NodeInfo.html , the new Linux ARM64 node) could use a manually built `genePredToGtf` binary for `aarch64`.

Another option would be to use `Sys.which("genePredToGtf")` but I think using the environment variable would be more flexible.